### PR TITLE
Update test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pyspark==2.3.0
+pyspark==2.3.2
 pytest==3.7.1
 pytest-cov==2.5.1


### PR DESCRIPTION
Changing the version of pyspark from 2.3.0 to 2.3.2 due to following security vulnerability
[CVE-2018-11760](https://nvd.nist.gov/vuln/detail/CVE-2018-11760)